### PR TITLE
docs: Update naming conventions in documentation

### DIFF
--- a/docs/guides/01-getting-started-cli.md
+++ b/docs/guides/01-getting-started-cli.md
@@ -1,6 +1,6 @@
 # Getting Started with mump2p CLI
 
-The `mump2p` CLI is the quickest way to interact with [OptimumP2P](https://github.com/getoptimum/optimum-p2p) without running your own infrastructure.
+The `mump2p` CLI is the quickest way to interact with [Optimum Network](https://github.com/getoptimum/optimum-p2p) without running your own infrastructure.
 
 In the next 5 minutes, you'll have:
 
@@ -8,11 +8,11 @@ In the next 5 minutes, you'll have:
 * Your first published message
 * A subscription feeding you live data
 
-The `mump2p` CLI is your shortcut into `OptimumP2P` — a high-performance, RLNC-enhanced peer-to-peer network.
+The `mump2p` CLI is your shortcut into `Optimum Network` — a high-performance, RLNC-enhanced peer-to-peer network.
 
 Instead of:
 
-* Manually locating and connecting to active OptimumP2P nodes
+* Manually locating and connecting to active Optimum Network nodes
 * Handling low-level peer discovery and connection logic
 * Managing complex network and encoding configurations
 
@@ -21,7 +21,7 @@ It connects to an `optimum-proxy` and lets you publish and subscribe to real-tim
 
 ## Why Optimum Proxy?
 
-OptimumP2P is a **peer-to-peer network** where nodes exchange messages over a `RLNC-enhanced` pubsub mesh.  
+Optimum Network is a **peer-to-peer network** where nodes exchange messages over a `RLNC-enhanced` pubsub mesh.  
 If you connect directly to a P2P node, you need to:
 
 * Know node IP/port.
@@ -31,7 +31,7 @@ If you connect directly to a P2P node, you need to:
 The **Optimum Proxies** removes that complexity:
 
 * Acts as **points of entry**.
-* Maintains connections to multiple OptimumP2P nodes.
+* Maintains connections to multiple Optimum Network nodes.
 * Enforces thresholds and applies filters.
 * Tracks usage and applies fair rate limits.
 

--- a/docs/guides/02-getting-started-docker.md
+++ b/docs/guides/02-getting-started-docker.md
@@ -1,19 +1,19 @@
 # Getting Started with Docker (Local Deployment)
 
-Running **OptimumP2P** locally with Docker gives you **full control** over configuration, topology, and experiments.  
+Running **Optimum Network** locally with Docker gives you **full control** over configuration, topology, and experiments.  
 You can run the network in two primary ways:
 
-**1. OptimumProxy + OptimumP2P** — Clients connect to an **Optimum Proxy**, which manages P2P connections for them.
+**1. OptimumProxy + mumP2P** — Clients connect to an **Optimum Proxy**, which manages P2P connections for them.
 
-![OptimumProxy + OptimumP2P Architecture](../../static/img/docker_1.png)
+![OptimumProxy + mumP2P Architecture](../../static/img/docker_1.png)
 
 * Simplifies client configuration — only the Proxy address is needed.
 * Proxy handles shard reassembly, threshold logic, and node selection automatically.
 * Easier scaling and centralized policy control.
 
-**2. Direct OptimumP2P** — Clients connect directly to **OptimumP2P nodes** (each node must run the gRPC API).
+**2. Direct mumP2P** — Clients connect directly to **mumP2P nodes** (each node must run the gRPC API).
 
-![Direct OptimumP2P Architecture](../../static/img/docker_2.png)
+![Direct mumP2P Architecture](../../static/img/docker_2.png)
 
 * Fewer network hops = potentially lower latency.
 * Clients must know node addresses and manage failover logic.
@@ -32,7 +32,7 @@ local deployment offers:
 
 Choose the deployment mode that best fits your use case:
 
-| **Mode A: Proxy + OptimumP2P** | **Mode B: Direct OptimumP2P** |
+| **Mode A: Proxy + mumP2P** | **Mode B: Direct mumP2P** |
 |---|---|
 | **One endpoint** — simpler client config | **Lowest latency** — fewer network hops |
 | **Policy control** — rate limiting, auth | **Direct control** — no proxy overhead |
@@ -40,14 +40,14 @@ Choose the deployment mode that best fits your use case:
 
 **Quick Decision:**
 
-* **Want simpler setup and client code?** → **[Start with Mode A](#4-mode-a--optimumproxy--optimump2p-recommended)**  
-* **Need maximum performance and control?** → **[Jump to Mode B](#5-mode-b--direct-optimump2p-advanced--lower-latency)**
+* **Want simpler setup and client code?** → **[Start with Mode A](#4-mode-a--optimumproxy--mump2p-recommended)**  
+* **Need maximum performance and control?** → **[Jump to Mode B](#5-mode-b--direct-mump2p-advanced--lower-latency)**
 
 ## 1. Before You Start
 
 ### Requirements
 
-* **[Docker](https://docs.docker.com/engine/install/)** — Container runtime for running OptimumP2P components
+* **[Docker](https://docs.docker.com/engine/install/)** — Container runtime for running Optimum Network components
 * **[Docker Compose](https://docs.docker.com/compose/install/)** — Tool for defining multi-container applications  
 * **[Go v1.24+](https://golang.org/dl/)** — Required for building custom gRPC clients
 * At least **2 GB free RAM** for running multiple nodes locally
@@ -62,7 +62,7 @@ Choose the deployment mode that best fits your use case:
 
 | Component           | Purpose                                                                                                                                 | Docker Images               |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| **OptimumP2P Node** | RLNC-enabled mesh peer, encodes/decodes message shards, handles peer discovery and subscriptions. Optional gRPC API for direct clients. | `getoptimum/p2pnode:v0.0.1-rc2` |
+| **mumP2P Node** | RLNC-enabled mesh peer, encodes/decodes message shards, handles peer discovery and subscriptions. Optional gRPC API for direct clients. | `getoptimum/p2pnode:v0.0.1-rc2` |
 | **Optimum Proxy**   | Bridges clients and the mesh, manages subscriptions, shard reassembly, threshold logic, and node selection.                             | `getoptimum/proxy:v0.0.1-rc3`   |
 
 
@@ -84,13 +84,13 @@ We’ll keep identity in `./identity` folder so you can reuse keys across restar
 
 | Recommended mode              | Why                                                                                       |
 | ----------------------------- | ----------------------------------------------------------------------------------------- |
-| **OptimumProxy + OptimumP2P** | One endpoint for clients, proxy handles matching, decoding thresholds, fanout, and policy |
-| **Direct OptimumP2P**         | Fewer hops, you control connection/retry logic and node selection                         |
+| **OptimumProxy + mumP2P** | One endpoint for clients, proxy handles matching, decoding thresholds, fanout, and policy |
+| **Direct mumP2P**         | Fewer hops, you control connection/retry logic and node selection                         |
 
 
 ## 3. Generate a Bootstrap Identity (once)
 
-OptimumP2P nodes need a **P2P identity** (cryptographic keypair) for peer-to-peer communication. The bootstrap node needs a persistent identity so other nodes can discover it reliably.
+mumP2P nodes need a **P2P identity** (cryptographic keypair) for peer-to-peer communication. The bootstrap node needs a persistent identity so other nodes can discover it reliably.
 
 **What is P2P Identity?**
 
@@ -111,7 +111,7 @@ This script:
 * Saves to `identity/p2p.key` with proper checksum format
 * Exports `BOOTSTRAP_PEER_ID` environment variable
 * Handles existing identity gracefully
-* Uses the correct file format expected by OptimumP2P nodes
+* Uses the correct file format expected by mumP2P nodes
 
 **Output:**
 
@@ -125,7 +125,7 @@ This script:
 [SUCCESS] Peer ID: 12D3KooWLsSmLLoE2T7JJ3ZyPqoXEusnBhsBA1ynJETsziCKGsBw
 [INFO] To use in docker-compose:
 export BOOTSTRAP_PEER_ID=12D3KooWLsSmLLoE2T7JJ3ZyPqoXEusnBhsBA1ynJETsziCKGsBw
-[SUCCESS] Done! Your OptimumP2P peer ID: 12D3KooWLsSmLLoE2T7JJ3ZyPqoXEusnBhsBA1ynJETsziCKGsBw
+[SUCCESS] Done! Your mumP2P peer ID: 12D3KooWLsSmLLoE2T7JJ3ZyPqoXEusnBhsBA1ynJETsziCKGsBw
 ```
 
 **What this creates:**
@@ -142,7 +142,7 @@ This guide covers:
 * Connecting via CLI (`mump2p-cli`) or `gRPC clients` (Go examples included).
 * Adjusting key parameters for your environment.
 
-## 4. Mode A — OptimumProxy + OptimumP2P (Recommended)
+## 4. Mode A — OptimumProxy + mumP2P (Recommended)
 
 ### Create the docker-compose file
 
@@ -477,7 +477,7 @@ func main() {
 }
 ```
 
-## 5. Mode B — Direct OptimumP2P (Advanced / Lower Latency)
+## 5. Mode B — Direct mumP2P (Advanced / Lower Latency)
 
 In this mode, clients connect `straight to node sidecar gRPC`. You’ll manage client-side reconnection, backoff, and which node to hit.
 
@@ -571,7 +571,7 @@ For a complete working P2P client that connects directly to nodes, see the full 
 The client includes:
 
 * **Message publishing and subscribing** with gRPC streaming
-* **Protocol trace handling** for both GossipSub and OptimumP2P
+* **Protocol trace handling** for both GossipSub and mumP2P
 * **Metrics collection** via `MessageTraceGossipSub` and `MessageTraceOptimumP2P` responses
 * **Stress testing capabilities** with batch message publishing
 
@@ -620,7 +620,7 @@ func main() {
     case protobuf.ResponseType_MessageTraceGossipSub:
       fmt.Printf("[TRACE] GossipSub trace: %d bytes\n", len(resp.GetData()))
     case protobuf.ResponseType_MessageTraceOptimumP2P:
-      fmt.Printf("[TRACE] OptimumP2P trace: %d bytes\n", len(resp.GetData()))
+      fmt.Printf("[TRACE] mumP2P trace: %d bytes\n", len(resp.GetData()))
     }
   }
 }

--- a/docs/guides/03-parameters.md
+++ b/docs/guides/03-parameters.md
@@ -1,6 +1,6 @@
-# Understanding Key Parameters in OptimumP2P
+# Understanding Key Parameters in mumP2P
 
-OptimumP2P nodes can operate in **two distinct protocol modes**, configured via:
+mumP2P nodes can operate in **two distinct protocol modes**, configured via:
 
 ```sh
 NODE_MODE=optimum    # RLNC-enhanced gossip
@@ -11,9 +11,9 @@ Each mode has its own parameter set, with some shared configurations.
 
 We support **two protocol modes** to let developers and researchers compare **performance, reliability, and bandwidth trade-offs** in real-world scenarios — without changing the rest of their infrastructure.
 
-## OptimumP2P (RLNC) Mode — `NODE_MODE=optimum`
+## mumP2P (RLNC) Mode — `NODE_MODE=optimum`
 
-OptimumP2P extends the gossip protocol with **Random Linear Network Coding**:
+mumP2P extends the gossip protocol with **Random Linear Network Coding**:
 
 * Messages are split into **shards**
 * Shards can be forwarded early once a threshold is reached
@@ -138,7 +138,7 @@ The following table shows the **production defaults**, which are optimized for t
 
 ### For Quick Start (Copy-Paste Ready)
 
-**OptimumP2P Mode (`NODE_MODE=optimum`):**
+**mumP2P Mode (`NODE_MODE=optimum`):**
 
 ```yaml
 environment:
@@ -204,5 +204,5 @@ environment:
 | `GOSSIPSUB_MESH_MAX`         | 12            | gossipsub    | Max peers before pruning                       |
 | `BOOTSTRAP_PEERS`            | []            | Both         | List of peer multiaddrs for bootstrap         |
 
-> **Note:** These are the production defaults used by OptimumP2P nodes. For experimental tuning, see [Common Experiments](./04-experiments.md).
+> **Note:** These are the production defaults used by mumP2P nodes. For experimental tuning, see [Common Experiments](./04-experiments.md).
 

--- a/docs/guides/04-experiments.md
+++ b/docs/guides/04-experiments.md
@@ -1,6 +1,6 @@
 # Common Experiments
 
-Once your OptimumP2P network is running (see [Parameters](./03-parameters.md)), you can try different experiments to understand **performance, reliability, and scaling behavior**.
+Once your Optimum Network is running (see [Parameters](./03-parameters.md)), you can try different experiments to understand **performance, reliability, and scaling behavior**.
 
 > **Before You Begin:**  
 > Make sure you’ve read:
@@ -17,9 +17,9 @@ You can run them using:
 
 
 
-## 1. GossipSub vs OptimumP2P
+## 1. GossipSub vs mumP2P
 
-**Goal:** Compare standard libp2p gossip to RLNC-enhanced gossip to confirm OptimumP2P is faster.
+**Goal:** Compare standard libp2p gossip to RLNC-enhanced gossip to confirm mumP2P is faster.
 
 **How:**
 
@@ -29,11 +29,11 @@ You can run them using:
 
 **Observe:**
 
-* **Delivery latency** (primary metric - OptimumP2P should be faster)
-* **Bandwidth usage** (OptimumP2P should use less)
+* **Delivery latency** (primary metric - mumP2P should be faster)
+* **Bandwidth usage** (mumP2P should use less)
 * **Success rate** (both should deliver messages successfully)
 
-**Expected Result:** OptimumP2P should show lower latency and bandwidth usage.
+**Expected Result:** mumP2P should show lower latency and bandwidth usage.
 
 
 ## 2. Shard Factor Sweep
@@ -74,13 +74,13 @@ You can run them using:
 
 ## 4. Mesh Density Impact
 
-**Goal:** Compare OptimumP2P vs GossipSub with different mesh sizes.
+**Goal:** Compare mumP2P vs GossipSub with different mesh sizes.
 
 **How:**
 
 * Test both `NODE_MODE=gossipsub` and `NODE_MODE=optimum`.
 * For GossipSub: try `GOSSIPSUB_MESH_TARGET` = 4, 6, 8.
-* For OptimumP2P: try `OPTIMUM_MESH_TARGET` = 6, 12, 18.
+* For mumP2P: try `OPTIMUM_MESH_TARGET` = 6, 12, 18.
 * Run the same publish/subscribe test.
 
 **Observe:**
@@ -88,7 +88,7 @@ You can run them using:
 * **Delivery latency** (primary metric)
 * **Bandwidth usage**
 
-**Expected Result:** OptimumP2P should perform better with higher mesh targets (around 12) while GossipSub optimal around 6.
+**Expected Result:** mumP2P should perform better with higher mesh targets (around 12) while GossipSub optimal around 6.
 
 
 
@@ -96,7 +96,7 @@ You can run them using:
 
 ## 5. Load Test
 
-**Goal:** Find when OptimumP2P vs GossipSub starts to fail under stress.
+**Goal:** Find when mumP2P vs GossipSub starts to fail under stress.
 
 **How:**
 
@@ -109,13 +109,13 @@ You can run them using:
 * **When delivery starts to fail** (primary metric)
 * **Delivery rate degradation**
 
-**Expected Result:** OptimumP2P should handle higher stress levels before failing compared to GossipSub.
+**Expected Result:** mumP2P should handle higher stress levels before failing compared to GossipSub.
 
 
 > **Tip:** Enable protocol traces in the gRPC client to get hop-by-hop delivery info:
 >
 > * `MessageTraceGossipSub` for GossipSub mode.
-> * `MessageTraceOptimumP2P` for OptimumP2P mode.
+> * `MessageTraceOptimumP2P` for mumP2P mode.
 
 ## Metrics Collection
 
@@ -128,7 +128,7 @@ For comprehensive metrics collection during experiments, use the gRPC P2P client
 The client automatically captures and displays:
 
 * **GossipSub traces**: Peer routing, message delivery status, hop counts, latency
-* **OptimumP2P traces**: Shard encoding/decoding, reconstruction efficiency, redundancy metrics  
+* **mumP2P traces**: Shard encoding/decoding, reconstruction efficiency, redundancy metrics  
 * **Message-level data**: Delivery success rates, end-to-end latency, bandwidth usage
 
 **Key trace handlers:**
@@ -138,7 +138,7 @@ case protobuf.ResponseType_MessageTraceGossipSub:
     fmt.Printf("[TRACE] GossipSub trace received: %s\n", string(resp.GetData()))
 
 case protobuf.ResponseType_MessageTraceOptimumP2P:
-    fmt.Printf("[TRACE] OptimumP2P trace received: %s\n", string(resp.GetData()))
+    fmt.Printf("[TRACE] mumP2P trace received: %s\n", string(resp.GetData()))
 ```
 
 Use this client instead of the CLI for detailed performance analysis during experiments.

--- a/docs/guides/05-faq-glossary.md
+++ b/docs/guides/05-faq-glossary.md
@@ -107,4 +107,4 @@ When something doesn't work:
 
 * **CLI Issues**: [mump2p-cli FAQ](https://github.com/getoptimum/mump2p-cli#faq---common-issues--troubleshooting)
 * **Setup Issues**: Check [`optimum-dev-setup-guide/docs/guide.md`](https://github.com/getoptimum/optimum-dev-setup-guide/blob/main/docs/guide.md)
-* **Protocol Questions**: See [OptimumP2P Documentation](./p2p.md)
+* **Protocol Questions**: See [mumP2P Documentation](./p2p.md)

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -1,12 +1,12 @@
 # Quick Start
 
-This developer guide is your complete reference for installing, configuring, and operating **OptimumP2P**.
+This developer guide is your complete reference for installing, configuring, and operating **Optimum Network**.
 
-This guide walks you through everything you need to **understand**, **deploy**, **run**, and **experiment** with OptimumP2P. It's designed for beginners but complete enough for advanced developers to jump in and integrate.
+This guide walks you through everything you need to **understand**, **deploy**, **run**, and **experiment** with Optimum Network. It's designed for beginners but complete enough for advanced developers to jump in and integrate.
 
 Whether you are an application developer, systems engineer, or hackathon participant, this guide will help you:
 
-1. **Install and run** OptimumP2P in different environments
+1. **Install and run** Optimum Network in different environments
 2. **Connect clients** via gRPC, REST, or CLI
 3. **Tune parameters** for performance or reliability
 4. **Run experiments** to validate system behavior
@@ -14,9 +14,9 @@ Whether you are an application developer, systems engineer, or hackathon partici
 
 ## Start Building
 
-Choose your path to get started with OptimumP2P:
+Choose your path to get started with Optimum Network:
 
-### **Try OptimumP2P (≤5 min)**
+### **Try mumP2P (≤5 min)**
 
 **[Using mump2p-cli](01-getting-started-cli.md)** — Connect to hosted proxy, no setup required
 
@@ -30,7 +30,7 @@ Choose your path to get started with OptimumP2P:
 
 * Complete local network deployment
 * Experiment with different parameters
-* Compare OptimumP2P vs GossipSub performance
+* Compare mumP2P vs GossipSub performance
 
 ### **Understanding & Experimenting**
 
@@ -62,7 +62,7 @@ This guide is organized into self-contained sections:
 
 ## Key Concepts
 
-Before diving deep, familiarize yourself with these terms and how they relate to OptimumP2P's architecture:
+Before diving deep, familiarize yourself with these terms and how they relate to Optimum Network's architecture:
 
 | Term         | Description |
 |--------------|-------------|
@@ -77,9 +77,9 @@ Before diving deep, familiarize yourself with these terms and how they relate to
 | **Direct P2P Mode** | Clients connect directly to P2P nodes via gRPC without going through a proxy. This can reduce latency but requires more configuration. |
 | **Mesh Parameters** | Settings such as `MESH_TARGET` that define how many peers a node tries to keep in its topic mesh. |
 | **Fanout**   | A temporary set of peers a publisher sends messages to when it is not part of the topic mesh. |
-| **Control Messages** | Special messages like GRAFT, PRUNE, IHAVE, IWANT used for GossipSub mesh management. OptimumP2P integrates similar control flows for RLNC. |
+| **Control Messages** | Special messages like GRAFT, PRUNE, IHAVE, IWANT used for GossipSub mesh management. mumP2P integrates similar control flows for RLNC. |
 | **Node Discovery** | The process by which proxies or nodes automatically learn about other nodes to connect to. |
 | **gRPC API** | The RPC interface provided by either a P2P node or a proxy for client communication. |
 
-For more technical details, see the **[OptimumP2P Technical Overview](../learn/overview/p2p.md)**.
+For more technical details, see the **[mumP2P Technical Overview](../learn/overview/p2p.md)**.
 

--- a/docs/learn/overview/intro.md
+++ b/docs/learn/overview/intro.md
@@ -12,9 +12,9 @@ Powered by [Random Linear Network Coding (RLNC)](./p2p.md#random-linear-network-
 
 ## Products
 
-Builders and operators can adopt **OptimumP2P** now for measurable latency gains. DeRAM and DeROM are next to unlock low-latency reads/writes.
+Builders and operators can adopt **mumP2P** now for measurable latency gains. DeRAM and DeROM are next to unlock low-latency reads/writes.
 
-### OptimumP2P
+### mumP2P
 
 RLNC-accelerated, libp2p/gossipsub-compatible pub/sub for fast, resilient propagation of blocks, blobs, and transactions.  
 **Get started:** [Overview](../../learn/overview/p2p.md) · [Quickstart](../../guides/01-getting-started-cli.md)
@@ -40,7 +40,7 @@ A **flexnode** is an operator-run node that participates in Optimum's coded goss
 
 ## Start here
 
-* **Try OptimumP2P (≤5 min):** [Using mump2p-cli](../../guides/01-getting-started-cli.md)
+* **Try mumP2P (≤5 min):** [Using mump2p-cli](../../guides/01-getting-started-cli.md)
 * **Run locally:** [Local Setup with Docker](../../guides/02-getting-started-docker.md)
 * **Integrate:** [Publish/Subscribe via Optimum Proxy endpoints](https://github.com/getoptimum/optimum-dev-setup-guide/blob/main/docs/guide.md#proxy-api)
 

--- a/docs/learn/overview/p2p.md
+++ b/docs/learn/overview/p2p.md
@@ -1,15 +1,15 @@
-# OptimumP2P
+# mumP2P Protocol
 
-**OptimumP2P** is a next-generation gossip protocol that uses [Random Linear Network Coding (RLNC)](https://x.com/get_optimum/status/1891520664726802439) to revolutionize message dissemination in peer-to-peer networks. Built on [libp2p](https://docs.libp2p.io/), it offers a high-performance alternative to traditional protocols like [GossipSub](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub), delivering faster propagation, better bandwidth efficiency, and better fault tolerance using network coding.
+**mumP2P** is a next-generation gossip protocol that uses [Random Linear Network Coding (RLNC)](https://x.com/get_optimum/status/1891520664726802439) to revolutionize message dissemination in peer-to-peer networks. Built on [libp2p](https://docs.libp2p.io/), it offers a high-performance alternative to traditional protocols like [GossipSub](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub), delivering faster propagation, better bandwidth efficiency, and better fault tolerance using network coding.
 
 
-## How OptimumP2P Works
+## How mumP2P Works
 
-OptimumP2P is a gossip mechanism based on RLNC, also known as **Galois Gossip**, that builds upon [libp2p](https://docs.libp2p.io/)'s [GossipSub](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub) protocol. Instead of transmitting complete messages between peers, OptimumP2P breaks messages into coded shards that can be independently forwarded and mathematically recombined to reconstruct the original data.
+mumP2P is a gossip mechanism based on RLNC, also known as **Galois Gossip**, that builds upon [libp2p](https://docs.libp2p.io/)'s [GossipSub](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub) protocol. Instead of transmitting complete messages between peers, mumP2P breaks messages into coded shards that can be independently forwarded and mathematically recombined to reconstruct the original data.
 
 ### Node Architecture
 
-Each OptimumP2P node is a standard libp2p host enhanced with RLNC logic. Core components include:
+Each mumP2P node is a standard libp2p host enhanced with RLNC logic. Core components include:
 
 * **libp2p Host** – Provides peer discovery, secure communication, and network transport.
 * **Mesh Topology** – Maintains a configurable gossip mesh with peer degrees similar to GossipSub.
@@ -60,7 +60,7 @@ When a node receives a shard:
 
 ### Control Messages
 
-OptimumP2P uses and extends [GossipSub's](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md#control-messages) control messages for optimized mesh performance:
+mumP2P uses and extends [GossipSub's](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md#control-messages) control messages for optimized mesh performance:
 
 | Message     | Purpose                                                                 |
 |-------------|-------------------------------------------------------------------------|
@@ -71,7 +71,7 @@ OptimumP2P uses and extends [GossipSub's](https://github.com/libp2p/specs/blob/m
 
 ## Configuration Parameters
 
-OptimumP2P provides several configurable parameters to tune performance for different network conditions and requirements:
+mumP2P provides several configurable parameters to tune performance for different network conditions and requirements:
 
 ### RLNC Encoding
 
@@ -81,21 +81,21 @@ OptimumP2P provides several configurable parameters to tune performance for diff
 
 ### Mesh Topology Parameters
 
-OptimumP2P builds upon libp2p's [GossipSub mesh topology](https://docs.libp2p.io/concepts/pubsub/overview/#full-message), where peers maintain **full-message peerings** for reliable data transmission and **metadata-only peerings** for gossip and network maintenance.
+mumP2P builds upon libp2p's [GossipSub mesh topology](https://docs.libp2p.io/concepts/pubsub/overview/#full-message), where peers maintain **full-message peerings** for reliable data transmission and **metadata-only peerings** for gossip and network maintenance.
 
 * **MeshDegreeTarget**: Target number of peers to maintain in the mesh overlay. This controls the trade-off between speed, reliability, resilience and efficiency of the network. A higher peering degree helps messages get delivered faster with better reliability, but increases bandwidth usage due to redundant message copies.
 * **MeshDegreeMin**: Minimum number of mesh peers before triggering [grafting](https://docs.libp2p.io/concepts/pubsub/overview/#grafting-and-pruning) (converting metadata-only connections to full-message).
 * **MeshDegreeMax**: Maximum number of mesh peers before triggering [pruning](https://docs.libp2p.io/concepts/pubsub/overview/#grafting-and-pruning) (converting full-message peerings back to metadata-only).
 
-In libp2p's default implementation, the ideal network peering degree is 6 with anywhere from 4–12 being acceptable. OptimumP2P inherits these mesh management mechanisms while optimizing shard propagation through the established topology.
+In libp2p's default implementation, the ideal network peering degree is 6 with anywhere from 4–12 being acceptable. mumP2P inherits these mesh management mechanisms while optimizing shard propagation through the established topology.
 
 ## Use Cases
 
-OptimumP2P serves as a foundational, general-purpose data propagation protocol with benefits extending across various blockchain use cases.
+mumP2P serves as a foundational, general-purpose data propagation protocol with benefits extending across various blockchain use cases.
 
 ### Validators and Node Operators
 
-OptimumP2P supercharges validator and full node performance in bandwidth-constrained and latency-sensitive networks:
+mumP2P supercharges validator and full node performance in bandwidth-constrained and latency-sensitive networks:
 
 * **[Ethereum](https://ethereum.org/)**: Faster mempool propagation, lower uncle rates, and potential integration into both execution and consensus layers.
 * **[Solana](https://solana.com/)**: Enhances Turbine-style data sharding with fault-tolerant packet loss recovery.  
@@ -114,7 +114,7 @@ High-frequency trading chains rely on fast, reliable state propagation:
 
 AI networks are data-intensive and latency-sensitive:
 
-* OptimumP2P enables fast gossiping of model weights, gradients, and other updates
+* mumP2P enables fast gossiping of model weights, gradients, and other updates
 * Supports high-throughput training/inference coordination across distributed nodes
 * Reduces straggler nodes and failed task replication due to packet loss
 
@@ -130,7 +130,7 @@ Decentralized physical infrastructure demands reliable node coordination at scal
 
 These chains rely on fast event propagation for user interactions:
 
-* OptimumP2P delivers low-latency, real-time interactions (game state syncs, social updates)
+* mumP2P delivers low-latency, real-time interactions (game state syncs, social updates)
 * Improves experience for multiplayer, onchain games and social dApps
 * Reduces costs of redundant relay infra through efficient data spreading
 
@@ -138,7 +138,7 @@ These chains rely on fast event propagation for user interactions:
 
 ## Security Model
 
-OptimumP2P inherits libp2p’s robust security foundation, and adds safeguards specific to network coding.
+mumP2P inherits libp2p's robust security foundation, and adds safeguards specific to network coding.
 
 ### Inherited from libp2p
 
@@ -147,11 +147,11 @@ OptimumP2P inherits libp2p’s robust security foundation, and adds safeguards s
 
 For a full overview of these protections, refer to the [libp2p security considerations](https://docs.libp2p.io/concepts/security/security-considerations/).
 
-### OptimumP2P avoids Pollution Attacks
+### mumP2P avoids Pollution Attacks
 
 In **pollution attacks** attack, a malicious actor injects corrupted or invalid coded shards into the network, with the goal of preventing honest nodes from successfully decoding the original message.
 
-OptimumP2P mitigates this risk through a multi-layered approach centered on **source authentication**.
+mumP2P mitigates this risk through a multi-layered approach centered on **source authentication**.
 
 *   The original message data is cryptographically hashed to create a unique identifier.
 *   This identifier, along with the publisher's signature, is bound to the data.


### PR DESCRIPTION
- Replace 'OptimumP2P' with 'mumP2P' for protocol references
- Replace 'OptimumP2P' with 'Optimum Network' for infrastructure references  
- Replace 'OptimumP2P' with 'Optimum' for general network references