### PR TITLE
Fix typo: "hetrogeneous" → "heterogeneous" in deram.md

### DIFF
--- a/docs/learn/overview/deram.md
+++ b/docs/learn/overview/deram.md
@@ -17,7 +17,7 @@ primitives. This flexibility contributes to improved durability, reduced
 bandwidth usage, and enhanced fault tolerance within a distributed storage
 framework.
 
-Our system is implemented as a network of functionally hetrogeneous nodes, termed
+Our system is implemented as a network of functionally heterogeneous nodes, termed
 Flexnodes, which collectively provide decentralized storage and communication
 services. External clients can interact with any Flexnode to perform read/write
 operations, using this system both for data storage and as a communication


### PR DESCRIPTION
Corrected a minor insignificant spelling error in the documentation file docs/learn/overview/deram.md.

- Original: "network of functionally hetrogeneous nodes"
- Corrected: "network of functionally heterogeneous nodes"

This change improves clarity and maintains consistency in technical terminology and in dictionary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed typographical error in network overview documentation.
  * Clarified Flexnode capabilities and external client interaction mechanisms within the decentralized network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->