### PR TITLE
fix misleading localhost comment for proxy_1 service URL

### DIFF
--- a/docs/guides/01-getting-started-cli.md
+++ b/docs/guides/01-getting-started-cli.md
@@ -154,8 +154,8 @@ Daily Quota:       5120.00 MB
 For testing without authentication:
 
 ```sh
-./mump2p --disable-auth --client-id="test-client" publish --topic=demo --message="Hello" --service-url="http://proxy_1:8081" # localhost
-./mump2p --disable-auth --client-id="test-client" subscribe --topic=demo --service-url="http://proxy_1:8081" # localhost
+./mump2p --disable-auth --client-id="test-client" publish --topic=demo --message="Hello" --service-url="http://proxy_1:8080" # docker network
+./mump2p --disable-auth --client-id="test-client" subscribe --topic=demo --service-url="http://proxy_1:8080" # docker network
 ```
 
 > **Complete Guide:** [Development mode documentation](https://github.com/getoptimum/mump2p-cli/blob/main/docs/guide.md#developmenttesting-mode) - covers all flags, usage, and examples


### PR DESCRIPTION
### What changed
- Fixed an incorrect comment that labeled `proxy_1` as `localhost` in the CLI getting-started guide.
- Updated the example to use the correct Docker network service URL.

### Why this matters
- `proxy_1` is a Docker service hostname and is not reachable via `localhost`.
- The previous example caused copy/paste failures for users running commands outside the Docker network.
- This change prevents confusion and aligns the documentation with actual Docker networking behavior.

### Scope
- Documentation-only change (no code or behavior changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI getting started guide with corrected example URLs for docker network environments, clarifying configuration for publish and subscribe operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->